### PR TITLE
Case sensitive import of rxjs

### DIFF
--- a/build/odata.d.ts
+++ b/build/odata.d.ts
@@ -1,5 +1,5 @@
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/rx';
+import { Observable } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 import { ODataQuery } from './query';
 import { GetOperation } from './operation';

--- a/build/odata.js
+++ b/build/odata.js
@@ -1,5 +1,5 @@
 "use strict";
-const rx_1 = require('rxjs/rx');
+const rx_1 = require('rxjs/Rx');
 const query_1 = require('./query');
 const operation_1 = require('./operation');
 class ODataService {

--- a/build/operation.d.ts
+++ b/build/operation.d.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams, Http, Response, RequestOptions } from '@angular/http';
-import { Observable } from 'rxjs/rx';
+import { Observable } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 export declare abstract class ODataOperation<T> {
     protected _typeName: string;

--- a/build/operation.js
+++ b/build/operation.js
@@ -1,6 +1,6 @@
 "use strict";
 const http_1 = require('@angular/http');
-const rx_1 = require('rxjs/rx');
+const rx_1 = require('rxjs/Rx');
 class ODataOperation {
     constructor(_typeName, config, http) {
         this._typeName = _typeName;

--- a/build/query.d.ts
+++ b/build/query.d.ts
@@ -1,5 +1,5 @@
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/rx';
+import { Observable } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 import { ODataOperation } from './operation';
 export declare class PagedResult<T> {

--- a/build/query.js
+++ b/build/query.js
@@ -1,5 +1,5 @@
 "use strict";
-const rx_1 = require('rxjs/rx');
+const rx_1 = require('rxjs/Rx');
 const operation_1 = require('./operation');
 class PagedResult {
 }

--- a/odata.ts
+++ b/odata.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams, Http, Response, Headers, RequestOptions } from '@angular/http';
-import { Observable, Operator } from 'rxjs/rx';
+import { Observable, Operator } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 import { ODataQuery } from './query';
 import { GetOperation } from './operation';

--- a/operation.ts
+++ b/operation.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { URLSearchParams, Http, Response, RequestOptions } from '@angular/http';
-import { Observable, Operator } from 'rxjs/rx';
+import { Observable, Operator } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 
 export abstract class ODataOperation<T> {

--- a/query.ts
+++ b/query.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { URLSearchParams, Http, Response } from '@angular/http';
-import { Observable, Operator, Subject } from 'rxjs/rx';
+import { Observable, Operator, Subject } from 'rxjs/Rx';
 import { ODataConfiguration } from './config';
 import { ODataOperation } from './operation';
 


### PR DESCRIPTION
In the rxjs library the `Rx.js` file is capitalized. Import with matching case to avoid issues on case sensitive files systems and warnings in webpack.
