### PR TITLE
getEntityUri() checks for type GUID

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,12 @@ export class ODataConfiguration {
 
 
     public getEntityUri(entityKey: string, _typeName: string) {
+        
+        // check if string is a GUID (UUID) type
+        if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(entityKey)) {
+            return this.baseUrl + '/' + _typeName + "(" + entityKey + ")";
+        }
+
         if (!/^[0-9]*$/.test(entityKey)) {
             return this.baseUrl + '/' + _typeName + "('" + entityKey + "')";
         }


### PR DESCRIPTION
Uses a REGEX pattern to determine if the incoming string is of type GUID and constructus a URI accordingly.